### PR TITLE
Respect environment's CFLAGS and other modernisations

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,7 +27,7 @@ jobs:
         cc: [ 'gcc-10']
     name: Run static analyzer ${{ matrix.cc }}
     env:
-      CFLAGS: '-Wall -Wextra -Werror -fanalyzer'
+      CFLAGS: '-Wall -Wextra -fanalyzer'
       CC: ${{ matrix.cc }}
     steps:
       - run: sudo apt update

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,38 @@
+on: [push, pull_request]
+
+jobs:
+  linuxbuild:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'ubuntu-16.04', 'ubuntu-18.04']
+        cc: [ 'gcc', 'clang' ]
+    name: Compile on ${{ matrix.cc }}
+    env:
+      CFLAGS: '-Wall -Wextra -Werror'
+      CC: ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir build
+      - run: cmake ..
+        working-directory: ./build
+      - run: cmake --build .
+        working-directory: ./build
+
+  analyzer:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-20.04']
+        cc: [ 'gcc']
+    name: Compile on ${{ matrix.cc }}
+    env:
+      CFLAGS: '-Wall -Wextra -Werror -fanalyzer'
+      CC: ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir build
+      - run: cmake ..
+        working-directory: ./build
+      - run: cmake --build .
+        working-directory: ./build

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,8 +30,6 @@ jobs:
       CFLAGS: '-Wall -Wextra -fanalyzer'
       CC: ${{ matrix.cc }}
     steps:
-      - run: sudo apt update
-      - run: sudo apt install gcc-10
       - uses: actions/checkout@v2
       - run: mkdir build
       - run: cmake ..

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,7 +27,7 @@ jobs:
         cc: [ 'gcc-10']
     name: Run static analyzer ${{ matrix.cc }}
     env:
-      CFLAGS: '-Wall -Wextra -fanalyzer'
+      CFLAGS: '-Wall -Wextra -Werror -fanalyzer'
       CC: ${{ matrix.cc }}
     steps:
       - uses: actions/checkout@v2
@@ -36,3 +36,4 @@ jobs:
         working-directory: ./build
       - run: cmake --build .
         working-directory: ./build
+        continue-on-error: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'ubuntu-16.04', 'ubuntu-18.04']
         cc: [ 'gcc', 'clang' ]
-    name: Compile on ${{ matrix.cc }}
+    name: Compile on ${{ matrix.os }} using ${{ matrix.cc }}
     env:
       CFLAGS: '-Wall -Wextra -Werror'
       CC: ${{ matrix.cc }}
@@ -24,12 +24,14 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04']
-        cc: [ 'gcc']
-    name: Compile on ${{ matrix.cc }}
+        cc: [ 'gcc-10']
+    name: Run static analyzer ${{ matrix.cc }}
     env:
       CFLAGS: '-Wall -Wextra -Werror -fanalyzer'
       CC: ${{ matrix.cc }}
     steps:
+      - run: sudo apt update
+      - run: sudo apt install gcc-10
       - uses: actions/checkout@v2
       - run: mkdir build
       - run: cmake ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ elseif (UNIX)
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC)
-	set(CMAKE_C_FLAGS "-Wall")
+	add_compile_options("-Wall")
 endif (CMAKE_COMPILER_IS_GNUCC)
 
 add_library (nsparklib ${NSPARK_LIB_SOURCE} ${NSPARK_OS_SOURCE})

--- a/compress.c
+++ b/compress.c
@@ -59,6 +59,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include "spark.h"
 #include "pack.h"
 #include "main.h"
@@ -416,7 +417,9 @@ getcode(FILE *ifp)
 	   pointers are being used. */
 	register char_type NSHUGE *bp = buf;
 
-	if (clear_flg > 0 || offset >= size || free_ent > maxcode)
+	assert(offset >= 0);
+
+	if (clear_flg > 0 || (size_t) offset >= size || free_ent > maxcode)
 	{
 		/*
 		 * If the next entry will be too big for the current code

--- a/compress.c
+++ b/compress.c
@@ -421,6 +421,7 @@ getcode(FILE *ifp)
 
 	if (clear_flg > 0 || (size_t) offset >= size || free_ent > maxcode)
 	{
+		int tmp_size;
 		/*
 		 * If the next entry will be too big for the current code
 		 * size, then we must increase the size.  This implies
@@ -438,9 +439,9 @@ getcode(FILE *ifp)
 		}
 		if (readsize == 0)
 			return (-1);
-		/* BB added cast to next line */
-		size = readsize < n_bits ? (size_t) readsize : n_bits;
-		size = fread(buf, 1, size, ifp);
+		tmp_size = readsize < n_bits ? readsize : n_bits;
+		assert(tmp_size >= 0);
+		size = fread(buf, 1, tmp_size, ifp);
 		if (size == 0)
 			return (-1);		/* end of file */
 		for (i = 0; i < size; i++)

--- a/error.c
+++ b/error.c
@@ -41,6 +41,8 @@ debug(char *fmt, ...)
 	va_start(ap, fmt);
 	vfprintf(stderr, fmt, ap);
 	va_end(ap);
+#else
+	(void)(fmt);
 #endif	/* DEBUGGING */
 }
 


### PR DESCRIPTION
Hello,

A handful of small fixes,

* cmake config fixed to avoid overwriting `CFLAGS`.
* Code updated to fix warnings.
* GitHub workflow added to build on a few compilers with `-Werror` etc.

I've added some configuration to run gcc's new static analyser against this code. It's not happy with the code, so I've set it to ignore errors.