### PR TITLE
Fix typo in man page

### DIFF
--- a/man/spark.5
+++ b/man/spark.5
@@ -3,7 +3,7 @@
 spark \- Archive file format for RISC OS version of the PC archiver Arc
 .SH CONVENTIONS
 Strings are given in ASCII with C-style escapes. No terminating \0 is
-present if not explicitily included.
+present if not explicitly included.
 
 Words are 32 bit little-endian numbers.
 

--- a/man/spark5.txt
+++ b/man/spark5.txt
@@ -11,7 +11,7 @@ NAME
 
 CONVENTIONS
      Strings are given in ASCII with  C-style  escapes.  No  ter-
-     minating   is present if not explicitily included.
+     minating   is present if not explicitly included.
 
      Words are 32 bit little-endian numbers.
 


### PR DESCRIPTION
Hello,

Just a silly typo correction. Reported by Debian's lintian, https://lintian.debian.org/sources/nspark?version=1.7.8B2%2Bgit20210317.cb30779-1